### PR TITLE
.gitattributes for newlines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-rails/bin/bundle eol=lf
-rails/bin/rails eol=lf
+rails/bin/* eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+rails/bin/bundle eol=lf
+rails/bin/rails eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 rails/bin/* eol=lf
+docker/* eol=lf
+bin/* eol=lf


### PR DESCRIPTION
Issue: running 'make rails-init' on Windows has /usr/bin/env: ‘ruby\r’: No such file or directory error

Running 'make rails-init' on Microsoft Windows has an error when running `rails/bin/rails` build step:

    C:\Workspace\tiddlyhost\tiddlyhost-github>make rails-init
    date: Tue, Nov 19, 2024 4:30:57 PM
    sha: f1810a9e18cd7e6b2a7c6fe9c744b2b8d64b478d
    build_number: 104
    commit: "chore: Refresh base images and update dependencies"
    branch: main
    curl -sL https://tiddlywiki.com/prerelease/empty.html -o rails/tw_content/empties/prerelease.html
    Created rails/public/tiddlywikicore-5.2.3.js.gz
    ...
    Created rails/public/tiddlywikicore-5.3.5.js.gz
    mkdir -p docker/postgresql-data/data16 docker/bundle docker/log docker/config docker/secrets node_modules docker/dotcache
    docker compose run --rm app bash -c "bin/bundle install && bin/rails yarn:install && bin/rails db:setup"
    [+] Creating 2/0
     ? Container th_cache  Running                                                                                  0.0s
     ? Container th_db     Running                                                                                  0.0s
    /usr/bin/env: ‘ruby\r’: No such file or directory
    /usr/bin/env: use -[v]S to pass options in shebang lines
    make: *** [Makefile:54: rails-init] Error 127
    
    C:\Workspace\tiddlyhost\tiddlyhost-github>

The issue is that the following files are checked out from github with '\r' on Windows:

    rails\bin\rails
    rails\bin\bundle


The following is a manual fix (on Windows system) to change the newline behavior using `sed`:

    sed -i 's/^M$//' rails\bin\rails
    sed -i 's/^M$//' rails\bin\bundle

This can be checked with the following; on Windows, the file has `\r`/CR character:

    C:\>file rails\bin\rails
    rails\bin\rails: Ruby script, ASCII text executable, with CRLF line terminators
    
    C:\>

After removing the `\r`/CR character:

    C:\>file rails\bin\rails
    rails\bin\rails: Ruby script, ASCII text executable
    
    C:\> 

This fix is adding `.gitattributes` for `rails/bin/rails` and `rails/bin/bundle` to retain `lf` newline behavior on checkout.