### PR TITLE
Rework node_modules volume mount, remove symlink

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # These volume mounts used when running containers can be ignored when building
-# (Todo maybe: put them in their own directory so we can use a wildcard here)
+# (Todo maybe: use a wildcard here)
 docker/bundle
+docker/node_modules
 docker/config
 docker/dotcache
 docker/letsencrypt
@@ -10,7 +11,6 @@ docker/postgresql-data
 docker/secrets
 
 # Rails stuff that should not be copied into the prod container
-rails/node_modules/*
 rails/tmp/*
 rails/log/*
 rails/storage/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ rails/storage
 rails/storage1
 rails/storage2
 rails/tw_content/empties/prerelease.html
-rails/node_modules/
 rails/public/assets/
 rails/public/tiddlywikicore-*-prerelease.js
 rails/public/tiddlywikicore-*.gz
@@ -27,6 +26,7 @@ docker/log
 docker/secrets
 docker/config
 docker/bundle
+docker/node_modules
 docker/dotcache
 etc/certbot-dns-user-credentials.yml
 etc/docker-conf/

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ build-push-base: cleanup build-base push-base
 # To set up your environment right after doing a git clone
 # Beware: This command runs `rails db:setup` which will clear out your local database
 DB_VOL_MOUNT=docker/postgresql-data/data16
-APP_VOL_MOUNTS=docker/bundle docker/log docker/config docker/secrets node_modules docker/dotcache
+APP_VOL_MOUNTS=docker/bundle docker/node_modules docker/log docker/config docker/secrets docker/dotcache
 rails-init: build-info js-math download-empty-prerelease gzip-core-js-files
 	mkdir -p $(DB_VOL_MOUNT) $(APP_VOL_MOUNTS)
 	$(DC) run --rm app bash -c "bin/bundle install && bin/rails yarn:install && bin/rails db:setup"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     volumes:
     - ./rails:/opt/app:Z
     - ./docker/bundle:/opt/bundle:Z
-    - ./node_modules:/opt/node_modules:Z
+    - ./docker/node_modules:/opt/app/node_modules:Z
     - ./docker/log:/var/log/app:Z
     - ./docker/dotcache:/home/appuser/.cache:Z
     command: /bin/start-rails.sh

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -26,7 +26,7 @@ RUN bundle install
 
 # Install node modules
 COPY --chown=$APP_USER:$APP_USER rails/package.json rails/yarn.lock ./
-RUN ln -s ../node_modules && yarn install --production
+RUN yarn install --production
 
 # Install the rails app, including some static files placed under rails/public,
 # excluding what's listed in .dockerignore

--- a/rails/node_modules
+++ b/rails/node_modules
@@ -1,1 +1,0 @@
-../node_modules


### PR DESCRIPTION
Adjust the development volume mount and remove the need for a symlink. Motivated by the fact that symlinks don't work well on Windows systems.

I was using a symlink to avoid having the node_modules volume mounted inside the rails volume, but actually that works fine.

I also moved the directory inside docker just for consistency with the other similar volume mounts.